### PR TITLE
Detect `literate` option by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,14 @@ module.exports = function(opt){
 
     var str = file.contents.toString('utf8');
 
-    var options = {};
+    var options = {
+        literate: /\.(litcoffee|coffee\.md)$/.test(file.path)
+    };
 
     if ( opt ) {
       options = {
         bare: opt.bare != null ? !!opt.bare : false,
-        literate: opt.literate != null ? !!opt.literate : false,
+        literate: opt.literate != null ? !!opt.literate : options.literate,
         sourceMap: opt.sourceMap != null ? !!opt.sourceMap : false
       }
     }

--- a/test/main.js
+++ b/test/main.js
@@ -125,6 +125,30 @@ describe('gulp-coffee', function() {
       stream.write(fakeFile);
     });
 
+    it('should compile a literate file (implicit)', function(done) {
+      var stream = coffee();
+      var fakeFile = new gutil.File({
+        path: "test/fixtures/journo.litcoffee",
+        base: "test/fixtures",
+        cwd: "test/",
+        contents: fs.readFileSync( 'test/fixtures/journo.litcoffee' )
+      });
+
+      stream.on('error', done);
+      stream.on('data', function(newFile){
+        should.exist(newFile);
+        should.exist(newFile.path);
+        should.exist(newFile.relative);
+        should.exist(newFile.contents);
+
+        newFile.path.should.equal("test/fixtures/journo.js");
+        newFile.relative.should.equal("journo.js");
+        String(newFile.contents).should.equal(fs.readFileSync('test/expected/journo.js', 'utf8'));
+        done();
+      });
+      stream.write(fakeFile);
+    });
+
     it('should compile a literate file (with bare)', function(done) {
       var stream = coffee({literate: true, bare: true});
       var fakeFile = new gutil.File({


### PR DESCRIPTION
This PR is relevant to the discussion in #6, where it was determined that auto-detection of the `literate` format based on file name would be bad for users who might have their own file extension naming scheme. The proposed change is that the default behavior is to detect the format, but allow the `literate` option to specify if necessary.

The basic idea is this: If the `literate` option is not defined, then the source file path is examined to attempt to automatically detect the format. If the `literate` option is defined, then that option is passed to the compiler regardless of file name. This behavior matches the expectation set by a similar feature of the Coffeescript command when given a file path to parse both with and without the `--literate` flag set.

See this [comment](https://github.com/wearefractal/gulp-coffee/pull/6#issuecomment-33064579) on #6 for more.
