### PR TITLE
Reorganize test suite to encapsulate repetative work

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -3,329 +3,201 @@ var should = require('should');
 var coffeescript = require('coffee-script');
 var gutil = require('gulp-util');
 var fs = require('fs');
+var path = require('path');
 require('mocha');
+
+var createFile = function (filepath, contents) {
+  var base = path.dirname(filepath);
+  return new gutil.File({
+    path: filepath,
+    base: base,
+    cwd: path.dirname(base),
+    contents: contents
+  });
+}
 
 describe('gulp-coffee', function() {
   describe('coffee()', function() {
+    before(function() {
+      this.testData = function (expected, newPath, done) {
+        var newPaths = [newPath];
+
+        if (expected.v3SourceMap) {
+          newPaths.unshift(newPath + '.map');
+          expected = [
+            expected.v3SourceMap,
+            expected.js + "\n/*\n//@ sourceMappingURL=" + path.basename(newPaths[0]) + "\n*/\n"
+          ];
+        } else {
+          expected = [expected];
+        }
+
+        return function (newFile) {
+          this.expected = expected.shift();
+          this.newPath = newPaths.shift();
+
+          should.exist(newFile);
+          should.exist(newFile.path);
+          should.exist(newFile.relative);
+          should.exist(newFile.contents);
+          newFile.path.should.equal(this.newPath);
+          newFile.relative.should.equal(path.basename(this.newPath));
+          String(newFile.contents).should.equal(this.expected);
+
+          if (done && !expected.length) {
+            done.call(this);
+          }
+        }
+      };
+    });
+
     it('should concat two files', function(done) {
-      var stream = coffee({bare: true});
-      var fakeFile = new gutil.File({
-        path: "/home/contra/test/file.coffee",
-        base: "/home/contra/test/",
-        cwd: "/home/contra/",
-        contents: new Buffer("a = 2")
-      });
+      var filepath = "/home/contra/test/file.coffee";
+      var contents = new Buffer("a = 2");
+      var opts = {bare: true};
+      var expected = coffeescript.compile(String(contents), opts);
 
-      var expected = coffeescript.compile(String(fakeFile.contents), {bare:true});
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        newFile.path.should.equal("/home/contra/test/file.js");
-        newFile.relative.should.equal("file.js");
-        String(newFile.contents).should.equal(expected);
-        done();
-      });
-      stream.write(fakeFile);
+      coffee(opts)
+        .on('error', done)
+        .on('data', this.testData(expected, "/home/contra/test/file.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should emit errors correctly', function(done) {
-      var stream = coffee({bare: true});
-      var fakeFile = new gutil.File({
-        path: "/home/contra/test/file.coffee",
-        base: "/home/contra/test/",
-        cwd: "/home/contra/",
-        contents: new Buffer("if a()\r\n  then huh")
-      });
+      var filepath = "/home/contra/test/file.coffee";
+      var contents = new Buffer("if a()\r\n  then huh");
 
-      var expected = "";
-
-      stream.on('error', function(err){
-        err.message.indexOf(fakeFile.path).should.not.equal(-1);
-        done();
-      });
-      stream.on('data', function(newFile){
-        throw new Error("no file should have been emitted!");
-      });
-      stream.write(fakeFile);
+      coffee({bare: true})
+        .on('error', function(err) {
+          err.message.indexOf(filepath).should.not.equal(-1);
+          done();
+        })
+        .on('data', function(newFile) {
+          throw new Error("no file should have been emitted!");
+        })
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a file (no bare)', function(done) {
-      var stream = coffee();
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/grammar.coffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/grammar.coffee' )
-      });
-      var expected = coffeescript.compile(String(fakeFile.contents));
+      var filepath = "test/fixtures/grammar.coffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var expected = coffeescript.compile(String(contents));
 
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        newFile.path.should.equal("test/fixtures/grammar.js");
-        newFile.relative.should.equal("grammar.js");
-        String(newFile.contents).should.equal(expected);
-        done();
-      });
-      stream.write(fakeFile);
+      coffee()
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/grammar.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a file (with bare)', function(done) {
-      var stream = coffee({bare: true});
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/grammar.coffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/grammar.coffee' )
-      });
-      var expected = coffeescript.compile(String(fakeFile.contents), {bare: true});
+      var filepath = "test/fixtures/grammar.coffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var opts = {bare: true};
+      var expected = coffeescript.compile(String(contents), opts);
 
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        newFile.path.should.equal("test/fixtures/grammar.js");
-        newFile.relative.should.equal("grammar.js");
-        String(newFile.contents).should.equal(expected);
-        done();
-      });
-      stream.write(fakeFile);
+      coffee(opts)
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/grammar.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a file with source map', function(done) {
-      var stream = coffee({sourceMap: true});
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/grammar.coffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/grammar.coffee' )
-      });
-
-      var expectedFilenames = ['grammar.js.map', 'grammar.js']
-      var expected = coffeescript.compile(String(fakeFile.contents), {
+      var filepath = "test/fixtures/grammar.coffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var expected = coffeescript.compile(String(contents), {
         sourceMap: true,
         sourceFiles: ['grammar.coffee'],
-        generatedFile: expectedFilenames[1]
+        generatedFile: 'grammar.js'
       });
-      expected = [
-        expected.v3SourceMap,
-        expected.js + "\n/*\n//@ sourceMappingURL=" + expectedFilenames[0] + "\n*/\n"
-      ];
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
 
-        var expectedFilename = expectedFilenames.shift()
-        newFile.path.should.equal("test/fixtures/" + expectedFilename);
-        newFile.relative.should.equal(expectedFilename);
-        String(newFile.contents).should.equal(expected.shift());
-        if(!expectedFilenames.length) done();
-      });
-      stream.write(fakeFile);
+      coffee({sourceMap: true})
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/grammar.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a file with bare and with source map', function(done) {
-      var stream = coffee({bare: true, sourceMap: true});
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/grammar.coffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/grammar.coffee' )
-      });
-
-      var expectedFilenames = ['grammar.js.map', 'grammar.js']
-      var expected = coffeescript.compile(String(fakeFile.contents), {
+      var filepath = "test/fixtures/grammar.coffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var expected = coffeescript.compile(String(contents), {
         bare: true,
         sourceMap: true,
         sourceFiles: ['grammar.coffee'],
-        generatedFile: expectedFilenames[1]
+        generatedFile: 'grammar.js'
       });
-      expected = [
-        expected.v3SourceMap,
-        expected.js + "\n/*\n//@ sourceMappingURL=" + expectedFilenames[0] + "\n*/\n"
-      ];
 
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        expectedFilename = expectedFilenames.shift()
-        newFile.path.should.equal("test/fixtures/" + expectedFilename);
-        newFile.relative.should.equal(expectedFilename);
-        String(newFile.contents).should.equal(expected.shift());
-        if(!expectedFilenames.length) done();
-      });
-      stream.write(fakeFile);
+      coffee({bare: true, sourceMap: true})
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/grammar.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a literate file', function(done) {
-      var stream = coffee({literate: true});
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/journo.litcoffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/journo.litcoffee' )
-      });
+      var filepath = "test/fixtures/journo.litcoffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var opts = {literate: true};
+      var expected = coffeescript.compile(String(contents), opts);
 
-      var expected = coffeescript.compile(String(fakeFile.contents), {literate: true});
-
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        newFile.path.should.equal("test/fixtures/journo.js");
-        newFile.relative.should.equal("journo.js");
-        String(newFile.contents).should.equal(expected);
-        done();
-      });
-      stream.write(fakeFile);
+      coffee(opts)
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/journo.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a literate file (implicit)', function(done) {
-      var stream = coffee();
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/journo.litcoffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/journo.litcoffee' )
-      });
+      var filepath = "test/fixtures/journo.litcoffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var expected = coffeescript.compile(String(contents), {literate: true});
 
-      var expected = coffeescript.compile(String(fakeFile.contents), {literate: true});
-
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        newFile.path.should.equal("test/fixtures/journo.js");
-        newFile.relative.should.equal("journo.js");
-        String(newFile.contents).should.equal(expected);
-        done();
-      });
-      stream.write(fakeFile);
+      coffee()
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/journo.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a literate file (with bare)', function(done) {
-      var stream = coffee({literate: true, bare: true});
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/journo.litcoffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/journo.litcoffee' )
-      });
+      var filepath = "test/fixtures/journo.litcoffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var opts = {literate: true, bare: true};
+      var expected = coffeescript.compile(String(contents), opts);
 
-      var expected = coffeescript.compile(String(fakeFile.contents), {literate: true, bare: true});
-
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        newFile.path.should.equal("test/fixtures/journo.js");
-        newFile.relative.should.equal("journo.js");
-        String(newFile.contents).should.equal(expected);
-        done();
-      });
-      stream.write(fakeFile);
+      coffee(opts)
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/journo.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a literate file with source map', function(done) {
-      var stream = coffee({literate: true, sourceMap: true});
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/journo.litcoffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/journo.litcoffee' )
-      });
-
-      var expectedFilenames = ['journo.js.map', 'journo.js']
-      var expected = coffeescript.compile(String(fakeFile.contents), {
+      var filepath = "test/fixtures/journo.litcoffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var expected = coffeescript.compile(String(contents), {
         literate: true,
         sourceMap: true,
         sourceFiles: ['journo.litcoffee'],
-        generatedFile: expectedFilenames[1]
+        generatedFile: 'journo.js'
       });
-      expected = [
-        expected.v3SourceMap,
-        expected.js + "\n/*\n//@ sourceMappingURL=" + expectedFilenames[0] + "\n*/\n"
-      ];
 
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        expectedFilename = expectedFilenames.shift()
-        newFile.path.should.equal("test/fixtures/" + expectedFilename);
-        newFile.relative.should.equal(expectedFilename);
-        String(newFile.contents).should.equal(expected.shift());
-        if(!expectedFilenames.length) done();
-      });
-      stream.write(fakeFile);
+      coffee({literate: true, sourceMap: true})
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/journo.js", done))
+        .write(createFile(filepath, contents));
     });
 
     it('should compile a literate file with bare and with source map', function(done) {
-      var stream = coffee({literate: true, bare: true, sourceMap: true});
-      var fakeFile = new gutil.File({
-        path: "test/fixtures/journo.litcoffee",
-        base: "test/fixtures",
-        cwd: "test/",
-        contents: fs.readFileSync( 'test/fixtures/journo.litcoffee' )
-      });
-
-      var expectedFilenames = ['journo.js.map', 'journo.js']
-      var expected = coffeescript.compile(fakeFile.contents.toString('utf8'), {
+      var filepath = "test/fixtures/journo.litcoffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var expected = coffeescript.compile(String(contents), {
         literate: true,
         bare: true,
         sourceMap: true,
         sourceFiles: ['journo.litcoffee'],
-        generatedFile: expectedFilenames[1]
+        generatedFile: 'journo.js'
       });
-      expected = [
-        expected.v3SourceMap,
-        expected.js + "\n/*\n//@ sourceMappingURL=" + expectedFilenames[0] + "\n*/\n"
-      ];
 
-      stream.on('error', done);
-      stream.on('data', function(newFile){
-        should.exist(newFile);
-        should.exist(newFile.path);
-        should.exist(newFile.relative);
-        should.exist(newFile.contents);
-
-        expectedFilename = expectedFilenames.shift()
-        newFile.path.should.equal("test/fixtures/" + expectedFilename);
-        newFile.relative.should.equal(expectedFilename);
-        String(newFile.contents).should.equal(expected.shift());
-        if(!expectedFilenames.length) done();
-      });
-      stream.write(fakeFile);
+      coffee({literate: true, bare: true, sourceMap: true})
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/journo.js", done))
+        .write(createFile(filepath, contents));
     });
   });
 });


### PR DESCRIPTION
No changes to the the plugin itself, just to the test suite.
Trivial changes, but perhaps easier to read, and hopefully easier to augment with new tests later.

Feel free to reject for superfluousness.
