### PR TITLE
Add header option (defaults to off)

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = function (opt) {
     if (opt) {
       options = {
         bare: opt.bare != null ? !! opt.bare : false,
+        header: opt.header != null ? !! opt.header : false,
         literate: opt.literate != null ? !! opt.literate : options.literate,
         sourceMap: opt.sourceMap != null ? !! opt.sourceMap : false,
         sourceRoot: opt.sourceRoot != null ? !! opt.sourceRoot : false,

--- a/test/main.js
+++ b/test/main.js
@@ -132,6 +132,28 @@ describe('gulp-coffee', function() {
         .write(createFile(filepath, contents));
     });
 
+    it('should compile a file (no header)', function(done) {
+      var filepath = "test/fixtures/grammar.coffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var expected = coffeescript.compile(String(contents), {header: false});
+
+      coffee()
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/grammar.js", done))
+        .write(createFile(filepath, contents));
+    });
+
+    it('should compile a file (with header)', function(done) {
+      var filepath = "test/fixtures/grammar.coffee";
+      var contents = new Buffer(fs.readFileSync(filepath));
+      var expected = coffeescript.compile(String(contents), {header: true});
+
+      coffee({header: true})
+        .on('error', done)
+        .on('data', this.testData(expected, "test/fixtures/grammar.js", done))
+        .write(createFile(filepath, contents));
+    });
+
     it('should compile a literate file', function(done) {
       var filepath = "test/fixtures/journo.litcoffee";
       var contents = new Buffer(fs.readFileSync(filepath));


### PR DESCRIPTION
I have been using the CoffeeScript compiler directly up until now and it outputs the header by default, and I didn't want to commit hundreds of files just to remove the header, and I noticed the header option isn't passed along.

It defaults to off, which retains the current behaviour.

Thanks!
