### PR TITLE
fixed sourceRoot option for sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,17 @@ module.exports = function (opt) {
         header: opt.header != null ? !! opt.header : false,
         literate: opt.literate != null ? !! opt.literate : options.literate,
         sourceMap: opt.sourceMap != null ? !! opt.sourceMap : false,
-        sourceRoot: opt.sourceRoot != null ? !! opt.sourceRoot : false,
         filename: file.path,
         sourceFiles: [path.basename(file.path)],
         generatedFile: path.basename(dest)
+      }
+      if (opt.sourceDest) {
+        options.sourceRoot = path.relative(
+          // real destination directory
+          path.dirname( path.join( process.cwd(), opt.sourceDest, path.relative( file.base, file.path ) ) ),
+          // source directory
+          path.dirname( file.path )
+        );
       }
     }
 


### PR DESCRIPTION
Pull request #21 is actually seriously broken for all but the extremely trivial case of not using any sub-directories in your CoffeeScript source directory.

As [described here](https://github.com/jashkenas/coffee-script/issues/3075#issue-16981090) `sourceRoot` discards any path information after the root directory.

In other words without this fix consider if `sourceRoot` is `../coffee/`, `gulp.dest` is `js/` and the file you are compiling happens to be `coffee/lib/util.coffee`. The result will be:

``` javascript
"sourceRoot": "../coffee/", // <- WRONG. Should be "../coffee/lib".
"sources": [
     "utils.coffee"
]
```

Instead we need to set `sourceRoot` on a **per-file basis** by computing the relative path from the **real** destination path back to source. It must be on a per-file basis because different files may reside at different locations or nesting levels within the CoffeeScript source directory structure.

Once you realize this is the issue then you find that you do not have the **real** destination at the point the coffee plugin is called in the gulp stream; i.e. The argument passed to `gulp.dest()` is not available at that point. So I have created a new option that has exactly the same semantics of `gulp.dest()` called `sourceDest`. `sourceDest` is then used to correctly calculate the relative path for `sourceRoot` on a per-file basis.

``` coffee
  gulp.src( 'coffee' )
    .pipe( plugins.coffee(
      bare: true
      sourceMap: true
      sourceDest: 'js' # pass exactly the same value as you pass to gulp.dest
    ) )
    .pipe( gulp.dest( 'js' ) )

```

This fix results in the previous example being correct:

``` javascript
"sourceRoot": "../coffee/lib", // <- CORRECT
"sources": [
     "utils.coffee"
]
```

In practice this has been tested with a non-trivial CoffeeScript source directory with many different levels and directories. It means that source maps can actually work simply by giving advance notice to the gulp-coffee plugin of what you will pass to `gulp.dest()`.

While this is a breaking change for any existing user of the recently added `sourceRoot` option I hope this explanation illustrates that the current semantics of the `sourceRoot` option are completely broken and cannot be fixed without this breaking change.

Thanks!
