### PR TITLE
keep the coffee version updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "event-stream": "^3.0.20",
-    "coffee-script": "~1.7.0",
+    "coffee-script": "~1.7.1",
     "gulp-util": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Error might happen while running 'make' if I use the up-to-date grammar sugar of coffee due to the outdated version.
