### PR TITLE
don't boolify string param "sourceRoot"

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (opt) {
         header: opt.header != null ? !! opt.header : false,
         literate: opt.literate != null ? !! opt.literate : options.literate,
         sourceMap: opt.sourceMap != null ? !! opt.sourceMap : false,
-        sourceRoot: opt.sourceRoot != null ? !! opt.sourceRoot : false,
+        sourceRoot: opt.sourceRoot,
         filename: file.path,
         sourceFiles: [path.basename(file.path)],
         generatedFile: path.basename(dest)


### PR DESCRIPTION
By default gulp-coffee specify sources in the sourcemap as filename, not as path. So, you cannot debug in IDEA or Chrome.

My gulp task:

``` javascript
gulp.task('compileTestData', function () {
  var sourceRoot = 'testData/coffee';
  gulp.src(sourceRoot + '/*.coffee')
      .pipe(changed(testDataCoffeeOut, {extension: '.js'}))
      .pipe(coffee({bare: true, sourceMap: true, sourceRoot: path.resolve(sourceRoot)}))
      .pipe(gulp.dest(testDataCoffeeOut))
});
```

Easy solution exists — just specify sourceRoot. But gulp-coffee boolify this option value, so, "/Users/develar/Documents/idea/plugins/JavaScriptDebugger/testApp/testData/coffee" converted to "true".
