### PR TITLE
Removes 0.9 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - unstable
   - 0.10


### PR DESCRIPTION
Builds on this repo are currently [failing](https://travis-ci.org/wearefractal/gulp-coffee/jobs/26170351) because the VM no longer has Node 0.9.

This PR removes the 0.9 requirement and adds the unstable tag mentioned in travis-ci/travis-ci#2252.

_EDIT_: apparently, `unstable` isn't supported yet.
