### PR TITLE
package.json: Use CoffeeScript 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulpplugin"
   ],
   "dependencies": {
-    "coffee-script": "1.7.0",
+    "coffee-script": "1.7.1",
     "event-stream": "^3.0.20",
     "gulp-util": "^2.2.1",
     "merge": "^1.1.3",


### PR DESCRIPTION
Tested: `npm test` will pass.

To review the changes, see https://github.com/jashkenas/coffeescript/compare/1.7.0...1.7.1
