### PR TITLE
Fix source and destination path in source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ module.exports = function (opt) {
       sourceRoot: false,
       literate: /\.(litcoffee|coffee\.md)$/.test(file.path),
       filename: file.path,
-      sourceFiles: [path.basename(file.path)],
-      generatedFile: path.basename(dest)
+      sourceFiles: [file.relative],
+      generatedFile: gutil.replaceExtension(file.relative, '.js')
     }, opt);
 
     try {


### PR DESCRIPTION
This fixes source map generation with `gulp-sourcemaps` for files located in a subdirectory. Probably also fixes what #24 is about.
