### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,4 @@
-.DS_Store
 *.log
-node_modules
 build
 *.node
 components


### PR DESCRIPTION
`.DS_Store` and `node_modules` are ignored by default. See the npm developer guide, [_Keeping files out of your package_](https://www.npmjs.org/doc/misc/npm-developers.html#keeping-files-out-of-your-package).
