### PR TITLE
Replace unneeded `merge`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var applySourceMap = require('vinyl-sourcemaps-apply');
 var path = require('path');
 var replaceExt = require('replace-ext');
 var PluginError = require('plugin-error');
-var merge = require('merge');
 
 module.exports = function (opt) {
   function replaceExtension(path) {
@@ -19,7 +18,7 @@ module.exports = function (opt) {
     var str = file.contents.toString('utf8');
     var dest = replaceExtension(file.path);
 
-    var options = merge({
+    var options = Object.assign({
       bare: false,
       coffee: require('coffeescript'),
       header: false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   ],
   "dependencies": {
     "coffeescript": "^2.1.0",
-    "merge": "^1.2.0",
     "plugin-error": "^0.1.2",
     "replace-ext": "^1.0.0",
     "through2": "^2.0.1",


### PR DESCRIPTION
We can use the native Object.assign() method.