### PR TITLE
Set sourceMap file

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ module.exports = function (opt) {
     }
 
     if (data && data.v3SourceMap && file.sourceMap) {
-      applySourceMap(file, data.v3SourceMap);
+      var sourceMap = JSON.parse(data.v3SourceMap);
+      sourceMap.file = file.sourceMap.file;
+      applySourceMap(file, sourceMap);
       file.contents = Buffer.from(data.js);
     } else {
       file.contents = Buffer.from(data);


### PR DESCRIPTION
Fixes #91 

The lib vinyl-sourcemaps-apply will throw an error if the sourceMap file property is not set. [They seem unwilling to remove the assertion](https://github.com/gulp-sourcemaps/gulp-sourcemaps/issues/83) that checks for the file property.

The changes seem to work with `gulp-sourcemaps`, but not with the gulp v4 built in sourcemaps, which doesn't work regardless.